### PR TITLE
dealing with no particular config

### DIFF
--- a/copperbench/bench.py
+++ b/copperbench/bench.py
@@ -33,7 +33,7 @@ class BenchConfig:
     request_cpus: int
     mem_limit: int
     runs: int = 1
-    executable: str = None
+    executable: Optional[str] = None
     working_dir: Optional[Path] = None
     symlink_working_dir: bool = True
     runsolver_kill_delay: int = 5

--- a/copperbench/bench.py
+++ b/copperbench/bench.py
@@ -41,7 +41,7 @@ class BenchConfig:
     timeout_factor: int = 1
     initial_seed: Optional[int] = None
     partition: str = 'broadwell'
-    cpu_per_node: int = 24
+    cpus_per_node: int = 24
     mem_lines: int = 4
     exclusive: bool = False
     cache_pinning: bool = True
@@ -67,8 +67,8 @@ def main() -> None:
     if bench_config.initial_seed != None:
         random.seed(bench_config.initial_seed)
     
-    cpus = int(math.ceil(bench_config.request_cpus / (bench_config.cpu_per_node / bench_config.mem_lines)) 
-                         * (bench_config.cpu_per_node / bench_config.mem_lines))
+    cpus = int(math.ceil(bench_config.request_cpus / (bench_config.cpus_per_node / bench_config.mem_lines)) 
+                         * (bench_config.cpus_per_node / bench_config.mem_lines))
     cache_lines = int(cpus / bench_config.mem_lines)
 
     instances = {}
@@ -241,7 +241,7 @@ def main() -> None:
         file.write('#\n')
         file.write(f'#SBATCH --job-name={bench_config.name}_compress\n')
         file.write(f'#SBATCH --partition={bench_config.partition}\n')
-        file.write(f'#SBATCH --cpus-per-task={int(bench_config.cpu_per_node / bench_config.mem_lines)}\n')
+        file.write(f'#SBATCH --cpus-per-task={int(bench_config.cpus_per_node / bench_config.mem_lines)}\n')
         file.write(f'#SBATCH --output=/dev/null\n')
         file.write(f'#SBATCH --error=/dev/null\n')
         file.write('#SBATCH --ntasks=1\n\n')

--- a/copperbench/bench.py
+++ b/copperbench/bench.py
@@ -98,6 +98,7 @@ def main() -> None:
     start_scripts = []
     
     for config_name, config in configs.items():
+        config = "" if config == "None" else config
         for instance_name, data in instances.items():
             for i in range(1, bench_config.runs + 1):
 

--- a/copperbench/bench.py
+++ b/copperbench/bench.py
@@ -48,6 +48,7 @@ class BenchConfig:
     cpu_freq: int = 2200
     use_perf: bool = True    
     runsolver_path: str = "/opt/runsolver"
+    billing: Optional[str] = None
 
 def main() -> None:
     
@@ -217,6 +218,10 @@ def main() -> None:
         file.write(f'#SBATCH --partition={bench_config.partition}\n')
         file.write(f'#SBATCH --cpus-per-task={cpus}\n')
         file.write(f'#SBATCH --mem-per-cpu={int(math.ceil(bench_config.mem_limit/cpus))}\n')
+        file.write(f'#SBATCH --mem-per-cpu={int(math.ceil(bench_config.mem_limit/cpus))}\n')
+        account = bench_config.billing
+        if account:
+            file.write(f'#SBATCH --account={account}\n')
         if bench_config.cache_pinning:
             file.write(f'#SBATCH --gres=cache:{cache_lines}\n')
         file.write(f'#SBATCH --cpu-freq={bench_config.cpu_freq*1000}-{bench_config.cpu_freq*1000}:performance\n')


### PR DESCRIPTION
An empty configs file may cause that variables like `slurm_time` are unbound, which causes a crash.

This commit fixes this issue if the user writes just "None" to the configs file.